### PR TITLE
Add codeowners file for the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# Docs for CODEOWNERS file:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @statisticsnorway/stratus will be requested for
+# review when someone opens a pull request.
+#
+* @statisticsnorway/stratus


### PR DESCRIPTION
The repo `Branches` settings requires review from Code Owners. This
file sets team Stratus as Code Owners.

Internal ref. [STRATUS-541]

Co-authored-by: bvestli <33520068+bvestli@users.noreply.github.com>
Co-authored-by: mmwinther <42948872+mmwinther@users.noreply.github.com>

[STRATUS-541]: https://statistics-norway.atlassian.net/browse/STRATUS-541