### PR TITLE
Initial Poetry setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Pycharm IDE settings
+.idea/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,8 @@
+package = []
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "ce2aa767160f871dd3652615ba0a0dceb7733d62eb8cb4665b87f30a562e3adf"
+
+[metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "bip-initializer"
+version = "0.1.0"
+description = "Generate everything your app needs to get started on BIP"
+authors = ["Miles Mason Winther <mmw@ssb.no>", "Bjørn Vestli <bjv@ssb.no>", "Lisa Wold Eriksen <lwe@ssb.no>"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Ran `poetry init` to generate `pyproject.toml`.
The `poetry.lock` file is included as it's recommended to do so, ref.
https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control

Internal ref. [STRATUS-541]

Co-authored-by: mmwinther <42948872+mmwinther@users.noreply.github.com>

[STRATUS-541]: https://statistics-norway.atlassian.net/browse/STRATUS-541