### PR TITLE
Change flux image tag pattern to variable

### DIFF
--- a/app/generate.py
+++ b/app/generate.py
@@ -11,6 +11,7 @@ router = APIRouter()
 class HRValues(BaseModel):
     name: str
     namespace: str
+    flux_image_tag_pattern: Optional[str] = "glob:main-*"
     cluster: str
     billingproject: str
     image_repository: str
@@ -25,6 +26,7 @@ class HRValues(BaseModel):
             "example": {
                 "name": "myapp",
                 "namespace": "stratus",
+                "flux_image_tag_pattern": "glob:main-*",
                 "cluster": "staging-bip-app",
                 "billingproject": "ssb-stratus",
                 "image_repository": "eu.gcr.io/prod-bip/ssb/stratus/myapp",

--- a/templates/helmrelease.j2
+++ b/templates/helmrelease.j2
@@ -7,7 +7,7 @@
     "annotations": {
       "fluxcd.io/ignore": "false",
       "fluxcd.io/automated": "true",
-      "fluxcd.io/tag.chart-image": "glob:master-*",
+      "fluxcd.io/tag.chart-image": "{{ flux_image_tag_pattern }}",
       "fluxcd.io/locked": "false"
     }
   },

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -5,6 +5,7 @@ def test_generate(client):
     post_data = """{
             "name": "am-hello-world",
             "namespace": "stratus",
+            "flux_image_tag_pattern" : "glob:main-*",
             "cluster": "staging-bip-app",
             "billingproject": "ssb-stratus",
             "image_repository": "eu.gcr.io/prod-bip/ssb/stratus/am-hello-world",
@@ -29,7 +30,7 @@ def test_generate(client):
              "annotations": {
                "fluxcd.io/ignore": "false",
                "fluxcd.io/automated": "true",
-               "fluxcd.io/tag.chart-image": "glob:master-*",
+               "fluxcd.io/tag.chart-image": "glob:main-*",
                "fluxcd.io/locked": "false"
              }
            },
@@ -66,6 +67,7 @@ def test_wrong_type(client):
     post_data = """{
               "name": "am-hello-world",
               "namespace": "stratus",
+              "flux_image_tag_pattern" : "glob:main-*",
               "cluster": "staging-bip-app",
               "billingproject": "ssb-stratus",
               "image_repository": "eu.gcr.io/prod-bip/ssb/stratus/am-hello-world",
@@ -86,6 +88,7 @@ def test_missing_value(client):
     post_data = """{
               "name": "am-hello-world",
               "namespace": "stratus",
+              "flux_image_tag_pattern" : "glob:main-*",
               "billingproject": "ssb-stratus",
               "image_repository": "eu.gcr.io/prod-bip/ssb/stratus/am-hello-world",
               "image_tag": "main-d2193bee3f24ae19e04d77826079d02cf58c0514",


### PR DESCRIPTION
The pattern of the flux image tag may vary. Developers may want to
tag their image with "master", "main" or "semver". To support this
they should be able to set the tag pattern through the API.

Internal ref. [STRATUS-542]

Co-authored-by: lisawolderiksen <35797988+lisawolderiksen@users.noreply.github.com>
Co-authored-by: bvestli <33520068+bvestli@users.noreply.github.com>

[STRATUS-542]: https://statistics-norway.atlassian.net/browse/STRATUS-542