### PR TITLE
Update release pipeline: Always use main branch

### DIFF
--- a/azure-pipeline-release.yml
+++ b/azure-pipeline-release.yml
@@ -1,3 +1,7 @@
+# NOTE: For this pipeline to work, you have to tag (in Git)
+# THE COMMIT WHICH IS THE MERGE COMMIT FOR A PR (otherwise there will be no GCR image to tag,
+# and the pipeline will fail)
+
 trigger:
   # Trigger from semantic version tags (for releasing to prod)
   tags:
@@ -30,5 +34,5 @@ stages:
   jobs:
   - template: docker/docker-tag-for-production.yml@templates
     parameters:
-      tagToTag: '$(Build.SourceBranchName)-$(Build.SourceVersion)'
+      tagToTag: 'main-$(Build.SourceVersion)'
       gcrImageName: '$(imageHost)/$(repoName)'


### PR DESCRIPTION
When tagging, the branchname available in the previously used variable
is not "main" and hence the tag doesn't exist in GCR. Given our build
and release process, the release tagging will always be performed on
the main branch, so might as well just hard code that value (since it
is hard to get from anywhere else).