### PR TITLE
Stratus 726 generate backend w exposed auth

### DIFF
--- a/app/generate.py
+++ b/app/generate.py
@@ -7,20 +7,20 @@ import json
 router = APIRouter()
 
 
-# Define the API schema
+# Define the API schema. Any values that we define a default
+# value for becomes optional in the request call.
 class HRValues(BaseModel):
     name: str
     namespace: str
-    flux_image_tag_pattern: Optional[str] = "glob:main-*"
+    flux_image_tag_pattern: str = "glob:main-*"
     cluster: str
     billingproject: str
     image_repository: str
     image_tag: str
-    # Required in ssb-chart but default values defined
     apptype: str = "backend"
     exposed: bool = False
     authentication: bool = True
-    port: Optional[int] = 80
+    port: int = 80
 
     class Config:
         schema_extra = {

--- a/app/generate.py
+++ b/app/generate.py
@@ -19,6 +19,7 @@ class HRValues(BaseModel):
     # Required in ssb-chart but default values defined
     apptype: str = "backend"
     exposed: bool = False
+    authentication: bool = True
     port: Optional[int] = 80
 
     class Config:
@@ -34,6 +35,7 @@ class HRValues(BaseModel):
                 "port": 8080,
                 "apptype": "backend",
                 "exposed": False,
+                "authentication": True,
             }
         }
 

--- a/templates/helmrelease.j2
+++ b/templates/helmrelease.j2
@@ -24,6 +24,11 @@
       "appType": "{{ apptype }}",
       "cluster": "{{ cluster }}",
       "exposed": "{{ exposed }}",
+      {% if not authentication %}
+        "IstionEndUserAuth" : {
+          "enabled" : "False"
+        },
+      {% endif %}
       "billingProject": "{{ billingproject }}",
       "image": {
         "repository": "{{ image_repository }}",

--- a/templates/helmrelease.j2
+++ b/templates/helmrelease.j2
@@ -23,7 +23,7 @@
       "name": "{{ name }}",
       "appType": "{{ apptype }}",
       "cluster": "{{ cluster }}",
-      "exposed": false,
+      "exposed": "{{ exposed }}",
       "billingProject": "{{ billingproject }}",
       "image": {
         "repository": "{{ image_repository }}",

--- a/templates/helmrelease.j2
+++ b/templates/helmrelease.j2
@@ -24,11 +24,9 @@
       "appType": "{{ apptype }}",
       "cluster": "{{ cluster }}",
       "exposed": "{{ exposed }}",
-      {% if not authentication %}
-        "IstionEndUserAuth" : {
-          "enabled" : "False"
-        },
-      {% endif %}
+      "istioEndUserAuth" : {
+        "enabled" : "{{ authentication }}"
+      },
       "billingProject": "{{ billingproject }}",
       "image": {
         "repository": "{{ image_repository }}",

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -48,8 +48,74 @@ def test_generate(client):
                "appType": "backend",
                "cluster": "staging-bip-app",
                "exposed": "False",
-               "IstionEndUserAuth": {
+               "istioEndUserAuth": {
                  "enabled": "False"
+               },
+               "billingProject": "ssb-stratus",
+               "image": {
+                 "repository": "eu.gcr.io/prod-bip/ssb/stratus/am-hello-world",
+                 "tag": "main-d2193bee3f24ae19e04d77826079d02cf58c0514"
+               },
+               "port": {
+                 "name": "http-am-hello-world",
+                 "containerport": 5000
+               }
+             }
+           }
+         }
+        """
+    assert response.json() == json.loads(expected_result)
+
+
+def test_generate_exposed_with_authentication(client):
+    post_data = """{
+            "name": "am-hello-world",
+            "namespace": "stratus",
+            "flux_image_tag_pattern" : "glob:main-*",
+            "cluster": "staging-bip-app",
+            "billingproject": "ssb-stratus",
+            "image_repository": "eu.gcr.io/prod-bip/ssb/stratus/am-hello-world",
+            "image_tag": "main-d2193bee3f24ae19e04d77826079d02cf58c0514",
+            "port": 5000,
+            "apptype": "backend",
+            "exposed": true,
+            "authentication": true
+        }"""
+    response = client.post(
+        "/api/v1/generate",
+        headers={"Content-Type": "application/json"},
+        json=json.loads(post_data),
+    )
+    assert response.status_code == 200
+    expected_result = """
+         {
+           "apiVersion": "helm.fluxcd.io/v1",
+           "kind": "HelmRelease",
+           "metadata": {
+             "name": "am-hello-world",
+             "namespace": "stratus",
+             "annotations": {
+               "fluxcd.io/ignore": "false",
+               "fluxcd.io/automated": "true",
+               "fluxcd.io/tag.chart-image": "glob:main-*",
+               "fluxcd.io/locked": "false"
+             }
+           },
+           "spec": {
+             "chart": {
+               "git": "ssh://git@github.com/statisticsnorway/platform-dev",
+               "ref": "master",
+               "path": "helm/charts/ssb-chart"
+             },
+             "releaseName": "am-hello-world",
+             "helmVersion": "v3",
+             "values": {
+               "name": "am-hello-world",
+               "appType": "backend",
+               "cluster": "staging-bip-app",
+               "exposed": "True",
+               "istioEndUserAuth": {
+                 "enabled": "True"
                },
                "billingProject": "ssb-stratus",
                "image": {

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -12,7 +12,8 @@ def test_generate(client):
             "image_tag": "main-d2193bee3f24ae19e04d77826079d02cf58c0514",
             "port": 5000,
             "apptype": "backend",
-            "exposed": false
+            "exposed": false,
+            "authentication": false
         }"""
     response = client.post(
         "/api/v1/generate",
@@ -46,7 +47,10 @@ def test_generate(client):
                "name": "am-hello-world",
                "appType": "backend",
                "cluster": "staging-bip-app",
-               "exposed": false,
+               "exposed": "False",
+               "IstionEndUserAuth": {
+                 "enabled": "False"
+               },
                "billingProject": "ssb-stratus",
                "image": {
                  "repository": "eu.gcr.io/prod-bip/ssb/stratus/am-hello-world",


### PR DESCRIPTION
The generate feature have been extended with parameters for backends with/without authentication.
A new test has also been added to verify that the new functionality works.

The parameter for exposed backend and authentication have default values and is therefore optional. 
This reduces the amount of input required from the user.

Internal ref.[STRATUS-744]
Co-authored-by: @lisawolderiksen 

[STRATUS-744]: https://statistics-norway.atlassian.net/browse/STRATUS-744