### PR TITLE
Update default container port for HelmRelease

### DIFF
--- a/app/generate.py
+++ b/app/generate.py
@@ -19,7 +19,7 @@ class HRValues(BaseModel):
     apptype: str = "backend"
     exposed: bool = False
     authentication: bool = True
-    port: int = 80
+    port: int = 8080
     health_probes: bool = True
     metrics: bool = True
 


### PR DESCRIPTION
This will update the default value for the container port to
reflect that a container port should be larger than
1024 so it not have to run as user root which is a security issue.